### PR TITLE
Fix infinite loop from empty password

### DIFF
--- a/xor.js
+++ b/xor.js
@@ -56,11 +56,13 @@ XorEncoder.prototype.encrypt = function(buffer) {
     };
 
     var valueChars = charArray(value);
-    var repeatedPassChars = charArray(repeatString(this.key, value));
+    if (this.key) {
+        var repeatedPassChars = charArray(repeatString(this.key, value));
+        var valueChars = xorArrays(valueChars, repeatedPassChars);
+    }
     var repeatedIVChars = charArray(repeatString(this.iv, value));
 
-    var pre = xorArrays(valueChars, repeatedIVChars);
-    var post = xorArrays(pre, repeatedPassChars);
+    var post = xorArrays(valueChars, repeatedIVChars);
 
     return  joinCharCodes(post);
 }


### PR DESCRIPTION
If you use xor 'encryption' but have an empty password the client ends up in an infinite loop. This change skips the entire key repetition + xoring step if the key is empty.

For reference, this behavior is supported by the official send_nsca client ([see utils.c](https://github.com/NagiosEnterprises/nsca/blob/master/src/utils.c#L356-L380)) 

